### PR TITLE
home page responsiveness fixed.

### DIFF
--- a/components/Intro.jsx
+++ b/components/Intro.jsx
@@ -25,20 +25,20 @@ export default function Intro() {
     <>
       <div className="w-full  h-full flex items-center lg:justify-start py-24 justify-center flex-wrap  ">
         <div className="lg:w-3/6 w-full sm:p-2 h-full my-2 flex items-center justify-center px-4 md:items-start md:justify-start md:p-20 flex-col ">
-          <h1 className="md:text-6xl text-2xl sm:text-2xl font-extrabold mb-4 text-black ">
+          <h1 className="md:text-6xl text-3xl sm:text-2xl font-extrabold mb-4 text-black ">
             To Choose Right Jobs.{" "}
-            <span className="text-sky-700"> JobSewa is for You</span>{" "}
+            <span className="block text-sky-700"> JobSewa is for You</span>{" "}
           </h1>
           <p className="md:text-lg sm:text-sm text-xs mb-20 text-gray-400">
             Thousands of people search for jobs daily on job portals on average.
           </p>
-          <div className="bg-white flex-col mb-6 w-full md:px-4   py-4 flex sm:flex-row items-center justify-center">
-            <BiSearchAlt className="text-2xl text-sky-700 mx-2 hidden sm:flex" />
+          <div className="bg-white mb-6 w-full md:px-4 py-2 md:py-4 pl-4 flex sm:flex-row items-center justify-center">
+            <BiSearchAlt className="text-2xl text-sky-700 mx-2 hidden sm:flex"/>
             <input
               onChange={(e) => setSearch(e.target.value)}
               type="text"
               placeholder="Search Jobs with Job Categories like electrician ..."
-              className="xs:w-full w-3/4  h-full px-2 bg-gray-200 text-base py-3 outline-none"
+              className="xs:w-full w-3/4 md:h-full p-2 md:px-2 md:py-3 bg-gray-200 text-base outline-none"
             />
             <button
               onClick={handleSearch}
@@ -52,13 +52,11 @@ export default function Intro() {
               <BsFillBookmarkFill className="text-sky-700 text-xl mx-2" />
               <h1 className="font-semibold text-lg">Suggest Tag : </h1>
             </div>
-            <div className="flex   items-center justify-center px-4 flex-wrap">
               <p className="px-2  text-gray-600">Electrician</p>
               <p className="px-2  text-gray-600">Labourer</p>
               <p className="px-2  text-gray-600">Driver</p>
               <p className="px-2  text-gray-600">Plumber</p>
               <p className="px-2  text-gray-600">Etc.</p>
-            </div>
           </div>
         </div>
         <div className="w-3/6 my-2 h-full bg-gray-200 hidden items-center justify-center flex-col p-20 lg:flex">


### PR DESCRIPTION
- The tagline was wrapped in the mobile view, which was unexpected. I fixed that issue.
- The search input and button were taking up too much space, and the visuals were not appealing. I made them look more professional.
- Suggested tags were not wrapping in the mobile view, but now they are wrapping correctly.

![image](https://github.com/user-attachments/assets/ebda819f-748c-4ed3-823a-e24fda2389be)
