### PR TITLE
fix forget password bug

### DIFF
--- a/pages/api/auth/forgetPassword.js
+++ b/pages/api/auth/forgetPassword.js
@@ -22,7 +22,7 @@ export default async (req, res) => {
         const ifExist = await User.findOne({ email });
         if(!ifExist) return res.status(404).json({ success: false, message: "Email Not Found" });
         const hashedPassword = await hash(password, 12)
-        const updatePassword =  await User.findOneAndUpdate({email  , password : hashedPassword });
+        const updatePassword =  await User.findOneAndUpdate({email},{password: hashedPassword});
         return res.status(201).json({ success: true, message: "Password Updated Successfully"  });
         
     } catch (error) {

--- a/pages/auth/forget-password.jsx
+++ b/pages/auth/forget-password.jsx
@@ -39,6 +39,7 @@ export default function ForgetPassword() {
 
     if (formData.password !== formData.confirmPassword) {
       toast.error("Password and Confirm Password does not match");
+      return;
     }
 
     const res = await forget_password(formData);


### PR DESCRIPTION
issue: #84 
**before behavior**
- forget password functionality does not work.
- even if the password and confirm password mismatch allow reset password.

**after behavior**
- forget password functionality works properly.
- only allow for reset password when password and confirm password match.

![Screenshot (103)](https://github.com/user-attachments/assets/bcbd35e2-697a-48f9-bdfe-9e3876b07208)
